### PR TITLE
feat: Dependabot Auto-approve and Merge PR - Javascript

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 * @endpointclosing/qe-code-review
+
+# No codeowners on these two files to allow dependabot to update. Re-add owners once dependabot can be added as a user
+package.json
+yarn.lock

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+
+version: 2
+updates:
+
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    rebase-strategy: "disabled"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00" # utc
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    rebase-strategy: "auto"
+    open-pull-requests-limit: 10
+    registries:
+      - npm-npmjs
+    schedule:
+      interval: 'daily'
+      time: '09:00' # utc
+    ignore:
+      - dependency-name: "*"
+        # To keep PR's from clogging up ignore majors for now
+        update-types: ["version-update:semver-major"]
+        # For Cypress, ignore all updates
+      - dependency-name: "cypress"
+
+registries:
+  npm-npmjs:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: ${{secrets.NPM_TOKEN_BOT}}
+

--- a/.github/workflows/dependabot_approve_and_merge.yml
+++ b/.github/workflows/dependabot_approve_and_merge.yml
@@ -1,0 +1,38 @@
+
+name: Dependabot Pull Request Approve and Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write  # Needed if in a private repository
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    # Checking the actor will prevent your Action run failing on non-Dependabot
+    # PRs but also ensures that it only does work for Dependabot PRs.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      # This step will fail if there's no metadata so approval won't occur.
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.6.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      # Here the PR gets approved.
+      - name: Approve a PR
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Sets PR to allow auto-merging for patch and minor updates if checks pass
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request creates a workflow for dependabot to approve pull requests for minor dependancy bumps, when the checks pass. Goal here is to have dependabot merge minor non-breaking dependabot PR's when they are generated. Since they are minor dependency updates which should be caught in automated testing risk should be low. It also sets the inteval and time to daily at 2am pst. All repos where this it makes sense to do this should merge this PR. Information on inititive: https://www.notion.so/endpointclosing/Dependabot-alert-backlog-cont-68f7645231014246a990ac1e4a4325ad